### PR TITLE
Add project charter for AI mock interview platform

### DIFF
--- a/PROJECT_CHARTER.md
+++ b/PROJECT_CHARTER.md
@@ -1,0 +1,62 @@
+## Project Charter: LangChain Interview Bot
+
+### 1. Project Overview
+Create a web-hosted AI agent using **LangChain** that conducts interactive interviews with users, stores responses, and provides insights or summaries. The system will run on a website with a clean UI, secure data handling, and scalable backend.
+
+---
+
+### 2. Objectives
+- **Automated Interviewer**: Guide users through structured or exploratory interviews in real time.
+- **Persistent Memory**: Retain conversation history to maintain context across questions.
+- **Analytics**: Summaries of conversations or extraction of key insights.
+- **Ease of Use**: Simple deployment, minimal setup, accessible from any browser.
+
+---
+
+### 3. Technical Approach
+
+| Layer | Technologies/Responsibilities |
+|-------|-------------------------------|
+| LLM & LangChain | Use LangChain for conversation orchestration. Select an LLM provider (OpenAI, Anthropic, etc.) and define prompts, tools, memory, and answer validation. |
+| Backend | FastAPI/Fastify or Express.js for REST endpoints. Manages authentication, session state, and interactions with the LangChain agent. |
+| Frontend | React or Next.js for a responsive UI that streams messages, collects answers, and displays conversation history. |
+| Data Storage | Database for transcript logs (e.g., PostgreSQL, MongoDB, or Supabase); object storage or blob for session artifacts. |
+| Deployment | Choose a platform (Vercel, Netlify, Render, AWS/GCP) to host both frontend and backend. Configure environment variables and CI/CD. |
+
+---
+
+### 4. Security and Privacy
+- Implement authentication and authorization to protect user data.
+- Store minimal PII; encrypt transcripts.
+- Allow users to export or delete their data.
+
+---
+
+### 5. Milestones & Deliverables
+| Phase | Deliverables |
+|-------|--------------|
+| **Planning** | Requirements, data schema, prompt design. |
+| **MVP** | Working local prototype: a CLI or simple web form using LangChain that interviews a user and stores responses. |
+| **Frontend Integration** | Full web UI with streaming answers and message history. |
+| **Deployment** | Hosted version with domain, SSL, environment config. |
+| **Analytics** | Automatic summarization or keyword extraction from interview results. |
+| **Testing & Launch** | User testing, load testing, and final production deployment. |
+
+---
+
+### 6. Risks & Mitigation
+- **LLM reliability**: cache responses, use fallback models or deterministic prompts.
+- **Scaling costs**: monitor API usage and plan for throttling or queueing.
+- **Data privacy**: anonymize or purge sensitive data regularly.
+
+---
+
+### 7. Success Metrics
+- Number of completed interviews.
+- User satisfaction scores or feedback.
+- Response accuracy or relevance based on manual review.
+- Server uptime and latency.
+
+---
+
+With this outline in place, you can start by building the local LangChain agent, iterate on prompts, then progressively integrate frontend, backend, and hosting. Let me know if you’d like code examples or a more detailed implementation plan.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Ai_Mock_Interview
 An AI-powered mock interview system that simulates real interview scenarios.
+
+See the [PROJECT_CHARTER](PROJECT_CHARTER.md) for goals, architecture, and milestones.


### PR DESCRIPTION
## Summary
- add project charter detailing goals, architecture, and milestones for LangChain-based mock interview system
- link charter from README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68babf4d482083218e848f4cec815175