### PR TITLE
Add demo CLI for interview bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,33 @@
 An AI-powered mock interview system that simulates real interview scenarios.
 
 See the [PROJECT_CHARTER](PROJECT_CHARTER.md) for goals, architecture, and milestones.
+
+## Demo CLI
+A small command-line demo shows how LangChain can power an interview bot.
+
+```bash
+pip install -r requirements.txt
+python demo_app.py
+```
+If you set the `OPENAI_API_KEY` environment variable the summary will use OpenAI; otherwise a mock LLM is used and a placeholder summary is returned. A JSON transcript is written to `transcript.json`.
+
+## Backend API
+A minimal FastAPI backend exposes interview endpoints.
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.app:app --reload
+```
+Endpoints:
+- `GET /questions` – list of interview questions
+- `POST /responses` – submit answers
+- `GET /summary` – summarise the transcript
+
+## Frontend
+A lightweight HTML/JS frontend lives in `frontend/index.html`.
+Serve it with any static web server, e.g.:
+
+```bash
+python -m http.server 5500
+```
+Then open http://localhost:5500/frontend/index.html in your browser while the backend runs on port 8000.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import List, Dict
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from langchain.chains import ConversationChain, LLMChain
+from langchain.memory import ConversationBufferMemory
+from langchain.prompts import PromptTemplate
+
+from demo_app import _load_llm
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+questions = [
+    "Tell me about yourself.",
+    "What is one strength you bring to a team?",
+    "Describe a challenge you've overcome.",
+]
+
+transcript: List[Dict[str, str]] = []
+llm = _load_llm()
+memory = ConversationBufferMemory(return_messages=True)
+conversation = ConversationChain(llm=llm, memory=memory)
+
+
+class Response(BaseModel):
+    question: str
+    answer: str
+
+
+@app.get("/questions")
+def get_questions() -> Dict[str, List[str]]:
+    return {"questions": questions}
+
+
+@app.post("/responses")
+def post_response(resp: Response) -> Dict[str, str]:
+    transcript.append(resp.dict())
+    conversation.predict(input=resp.answer)
+    return {"status": "recorded"}
+
+
+@app.get("/summary")
+def get_summary() -> Dict[str, str]:
+    prompt = PromptTemplate.from_template(
+        "Summarise the following interview transcript:\n{transcript}"
+    )
+    summary_chain = LLMChain(llm=llm, prompt=prompt)
+    formatted = "\n".join(
+        f"Q: {t['question']}\nA: {t['answer']}" for t in transcript
+    )
+    summary = summary_chain.run(transcript=formatted).strip()
+    return {"summary": summary}

--- a/demo_app.py
+++ b/demo_app.py
@@ -1,0 +1,83 @@
+"""Simple CLI demo for LangChain Interview Bot.
+
+This script asks the user a few interview questions, stores
+responses, and summarises the conversation using LangChain.
+If an OpenAI API key is available, it will use ChatOpenAI for
+summarisation. Otherwise a fake LLM is used so the demo can run
+offline.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Dict
+
+from langchain.chains import LLMChain
+from langchain.chains import ConversationChain
+from langchain.memory import ConversationBufferMemory
+from langchain.prompts import PromptTemplate
+
+
+def _load_llm():
+    """Return an LLM instance.
+
+    If ``OPENAI_API_KEY`` is set, the OpenAI chat model is used.
+    Otherwise a ``FakeListLLM`` provides deterministic responses so the
+    demo can run without external dependencies.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        from langchain_openai import ChatOpenAI
+
+        # temperature 0 for deterministic behaviour
+        return ChatOpenAI(temperature=0)
+    else:
+        from langchain_community.llms.fake import FakeListLLM
+
+        # One response for the summary chain.
+        return FakeListLLM(responses=["(mock) Summary not available without an API key."])
+
+
+def run_interview(questions: List[str]) -> Dict[str, List[Dict[str, str]]]:
+    """Conduct a simple interview and return the transcript and summary."""
+    llm = _load_llm()
+    memory = ConversationBufferMemory(return_messages=True)
+    conversation = ConversationChain(llm=llm, memory=memory)
+
+    transcript: List[Dict[str, str]] = []
+    for q in questions:
+        print(f"\nInterviewer: {q}")
+        answer = input("You: ")
+        transcript.append({"question": q, "answer": answer})
+        # store the turn in memory
+        conversation.predict(input=answer)
+
+    # Summarise the conversation
+    prompt = PromptTemplate.from_template(
+        "Summarise the following interview transcript:\n{transcript}"
+    )
+    summary_chain = LLMChain(llm=llm, prompt=prompt)
+    formatted = "\n".join(
+        f"Q: {t['question']}\nA: {t['answer']}" for t in transcript
+    )
+    summary = summary_chain.run(transcript=formatted).strip()
+
+    return {"transcript": transcript, "summary": summary}
+
+
+def main() -> None:
+    questions = [
+        "Tell me about yourself.",
+        "What is one strength you bring to a team?",
+        "Describe a challenge you've overcome.",
+    ]
+    result = run_interview(questions)
+    # Save transcript
+    with open("transcript.json", "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+    print("\nInterview summary:\n" + result["summary"])
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Interview Bot</title>
+</head>
+<body>
+  <h1>LangChain Interview Bot</h1>
+  <div id="conversation"></div>
+  <p id="question"></p>
+  <input id="answer" type="text" placeholder="Type your answer" />
+  <button id="submit">Submit</button>
+  <script>
+    async function main() {
+      const qRes = await fetch('http://localhost:8000/questions');
+      const qData = await qRes.json();
+      const questions = qData.questions;
+      let index = 0;
+      const conversation = document.getElementById('conversation');
+      const questionEl = document.getElementById('question');
+      const answerEl = document.getElementById('answer');
+      const submitBtn = document.getElementById('submit');
+
+      function ask() {
+        if (index < questions.length) {
+          questionEl.textContent = questions[index];
+          answerEl.value = '';
+        } else {
+          questionEl.textContent = 'Interview complete.';
+          submitBtn.disabled = true;
+          fetch('http://localhost:8000/summary')
+            .then(r => r.json())
+            .then(data => {
+              const p = document.createElement('p');
+              p.textContent = 'Summary: ' + data.summary;
+              conversation.appendChild(p);
+            });
+        }
+      }
+
+      submitBtn.onclick = async () => {
+        const payload = { question: questions[index], answer: answerEl.value };
+        await fetch('http://localhost:8000/responses', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const p = document.createElement('p');
+        p.textContent = `Q: ${questions[index]}\nA: ${answerEl.value}`;
+        conversation.appendChild(p);
+        index++;
+        ask();
+      };
+
+      ask();
+    }
+    main();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+langchain
+langchain-community
+langchain-openai
+openai
+
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add `demo_app.py` demonstrating a LangChain-powered interview that stores replies and produces a summary
- document running the demo and dependencies
- add FastAPI backend with endpoints for questions, responses, and summary
- add lightweight HTML/JS frontend consuming the API

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
from fastapi.testclient import TestClient
from backend.app import app

client = TestClient(app)
q = client.get('/questions').json()
print('Questions:', q)
client.post('/responses', json={'question': q['questions'][0], 'answer': 'I am a tester'})
summary = client.get('/summary').json()
print('Summary:', summary)
PY`
- `python -m http.server 5500 &
SERVER=$!
sleep 1
curl -I http://localhost:5500/frontend/index.html
kill $SERVER`

------
https://chatgpt.com/codex/tasks/task_e_68bac75027e48321859feee69db206ae